### PR TITLE
package.json: Fix typo in URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github/voldikss/coc-cmake"
+    "url": "https://github.com/voldikss/coc-cmake"
   },
-  "homepage": "https://github/voldikss/coc-cmake#readme",
+  "homepage": "https://github.com/voldikss/coc-cmake#readme",
   "engines": {
     "coc": "^0.0.74"
   },


### PR DESCRIPTION
Searching your repo in order to give it a star, it took me a while to figure out why my browser didn't manage to find GitHub :).