### PR TITLE
Tame error messages when cmake is missing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -142,6 +142,8 @@ async function onLineHelp(): Promise<void> {
   }
 }
 
+let is_cmake_missing = false;
+
 /// strings Helpers
 function strContains(word, pattern): boolean {
   return word.indexOf(pattern) > -1
@@ -195,8 +197,9 @@ async function cmake(args: string[]): Promise<string> {
       stdout += txt.replace(/\r/gm, '')
     })
     cmd.on("error", error => {
-      if (error && (error as any).code === 'ENOENT') {
-        workspace.showMessage('The "cmake" command is not found in PATH.  Install it or use `cmake.cmakePath` in the workspace settings to define the CMake executable binary.', 'error')
+      if (!is_cmake_missing && error && (error as any).code === 'ENOENT') {
+        is_cmake_missing = true;
+        workspace.showMessage('Install cmake or specify its path via the workspace config `cmake.cmakePath`.', 'error')
       }
       reject()
     })


### PR DESCRIPTION
When cmake is missing, coc-cmake shows an error message on every key press. This error message blocks the editor and takes seven "enter"-s to dismiss.

![Screenshot from 2020-12-20 04-45-34](https://user-images.githubusercontent.com/7343721/102698317-ccd93980-427f-11eb-9314-76b500ab1c78.png)

To fix this issue I've made 2 changes with this PR:

- Make the message shorter (<80 chars) to avoid hit-enter prompts, thereby un-blocking Vim
- Only show the message once in an editing session