### PR TITLE
fix: install fails because pip is using pip2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-cmake",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "coc.nvim extension for cmake language",
   "main": "lib/index.js",
   "publisher": "voldikss",

--- a/src/provider/format.ts
+++ b/src/provider/format.ts
@@ -60,7 +60,7 @@ async function format(document: TextDocument, range?: Range): Promise<string> {
         'cmake-format is not installed, install it?'
       )
       if (install) {
-        await window.openTerminal('pip install cmake-format')
+        await window.openTerminal('pip3 install cmake-format')
       }
       return ''
     }


### PR DESCRIPTION
in ubuntu18.04 & ubuntu20.04, pip is default to pip2 it seems. So coc-cmake failed to install cmakelang