### PR TITLE
Add "formatter_args" property to the coc config;

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ Type: <pre><code>string</code></pre>Default: <pre><code>"cmake"</code></pre>
 Type: <pre><code>string</code></pre>Default: <pre><code>"cmake-format"</code></pre>
 </details>
 <details>
+<summary><code>cmake.formatter_args</code>: Additional arguments to be passed down to the formatter.</summary>
+Type: <pre><code>string[]</code></pre>Default: <pre><code>[]</code></pre>
+</details>
+<details>
 <summary><code>cmake.lsp.enable</code>: Enable language server(https://github.com/regen100/cmake-language-server), Notice that the functionality(completion, formatting, etc.) of lsp and extension builtin can not coexist.</summary>
 Type: <pre><code>boolean</code></pre>Default: <pre><code>false</code></pre>
 </details>
@@ -47,6 +51,192 @@ Type: <pre><code>boolean</code></pre>Default: <pre><code>false</code></pre>
 Type: <pre><code>string</code></pre>Default: <pre><code>"cmake-language-server"</code></pre>
 </details>
 <details>
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
+<summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
+Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
+</details>
+
+<!-- prettier-ignore-end -->
+
 <summary><code>cmake.lsp.buildDirectory</code>: See https://github.com/regen100/cmake-language-server#configuration.</summary>
 Type: <pre><code>string</code></pre>Default: <pre><code>"build"</code></pre>
 </details>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coc-cmake",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "coc.nvim extension for cmake language",
   "main": "lib/index.js",
   "publisher": "voldikss",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,14 @@
           "default": "cmake-format",
           "description": "Path to [cmake-format](https://github.com/cheshirekow/cmake_format)"
         },
+        "cmake.formatter_args": {
+          "type": "array",
+          "default": [],
+          "description": "Additional arguments to be passed down to the formatter",
+          "items": {
+            "type":"string"
+          }
+        },
         "cmake.lsp.enable": {
           "type": "boolean",
           "default": false,
@@ -70,7 +78,7 @@
   "author": "dyzplus@gmail.com",
   "license": "MIT",
   "devDependencies": {
-    "@types/node": "^14.14.10",
+    "@types/node": "^14.17.15",
     "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
@@ -78,14 +86,15 @@
     "coc.nvim": "^0.0.80",
     "command-exists": "^1.2.9",
     "eslint": "^7.16.0",
+    "json-schema-to-typescript": "^10.1.2",
+    "npm-run-all": "^4.1.5",
     "opener": "^1.5.2",
     "rimraf": "^3.0.2",
     "tmp": "^0.2.1",
     "ts-loader": "^8.0.12",
+    "tslib": "^1.14.1",
     "tslint": "^6.1.3",
     "typescript": "^4.1.2",
-    "json-schema-to-typescript": "^10.1.2",
-    "npm-run-all": "^4.1.5",
     "webpack": "^5.11.1",
     "webpack-cli": "^4.3.0"
   }

--- a/src/provider/format.ts
+++ b/src/provider/format.ts
@@ -40,8 +40,11 @@ export default class CMakeFormattingEditProvider
 
 async function format(document: TextDocument, range?: Range): Promise<string> {
   const formatter = getConfig<string>('formatter')
-  const args = []
+  const args = Array.from(getConfig<Array<string>>('formatter_args'))
   if (!range) {
+    if (args.length != 0){
+      args.push("--")
+    }
     args.push(Uri.parse(document.uri).fsPath)
   } else {
     // write the selected code into a tmp file and invoke formatter

--- a/src/types/pkg-config.d.ts
+++ b/src/types/pkg-config.d.ts
@@ -15,6 +15,10 @@ export interface CMake {
    */
   'cmake.formatter'?: string;
   /**
+   * Additional arguments to be passed down to the formatter
+   */
+  'cmake.formatter_args'?: string[];
+  /**
    * Enable language server(https://github.com/regen100/cmake-language-server), Notice that the functionality(completion, formatting, etc.) of lsp and extension builtin can not coexist
    */
   'cmake.lsp.enable'?: boolean;


### PR DESCRIPTION
Hi @voldikss,
First of all, thank you for all the hard work on coc and this plugin especially;
This pr offers to add a `formatter_args` property to a (local/global) coc-settings.json, that allows for tighter control over the configuration file for the formatter;

Motivation:
in accordance with [the docs](https://cmake-format.readthedocs.io/en/latest/format-usage.html): 
"Formatting is configurable by providing a configuration file. The configuration
file can be in json, yaml, or python format. If no configuration file is
specified on the command line, cmake-format will attempt to find a suitable
configuration for each ``inputpath`` by checking recursively checking it's
parent directory up to the root of the filesystem'."

so, in my case the requirement is that the config files for all linters and formatters shall be stored in a separate file, unrelated to the project's source code directory; thus the need for tighter control;

Thank you for reviewing!